### PR TITLE
Fixed invalid template string.

### DIFF
--- a/src/lib/mocha-testrail-reporter.ts
+++ b/src/lib/mocha-testrail-reporter.ts
@@ -91,7 +91,7 @@ ${test.err}`
             throw new Error("Missing --reporter-options in mocha.opts");
         }
         if (options[name] == null) {
-            throw new Error("Missing ${name} value. Please update --reporter-options in mocha.opts");
+            throw new Error(`Missing ${name} value. Please update --reporter-options in mocha.opts`);
         }
     }
 }


### PR DESCRIPTION
One of the error messages was referencing a variable as if it were a template string, but it was defined with quotes instead of back ticks. This change fixes this so the error message regarding missing option values now prints which option was missing.