### PR TITLE
Support for user-provided runId

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rimraf dist",
-    "test": "mocha dist/test",
+    "test": "mocha --require dotenv/config dist/test",
     "build": "npm run clean && npm run tsc"
   },
   "dependencies": {
@@ -40,6 +40,8 @@
     "@types/mocha": "^2.2.36",
     "@types/node": "^6.0.58",
     "chai": "^3.5.0",
+    "dotenv": "^5.0.0",
+    "mocha": "^5.0.1",
     "rimraf": "^2.5.4",
     "typescript": "^2.1.4"
   }

--- a/src/lib/mocha-testrail-reporter.ts
+++ b/src/lib/mocha-testrail-reporter.ts
@@ -1,7 +1,7 @@
 import {reporters} from 'mocha';
 import {TestRail} from "./testrail";
 import {titleToCaseIds} from "./shared";
-import {Status, TestRailResult} from "./testrail.interface";
+import {Status, TestRailResult, TestRailOptions} from "./testrail.interface";
 
 
 export class MochaTestRailReporter extends reporters.Spec {
@@ -19,7 +19,7 @@ export class MochaTestRailReporter extends reporters.Spec {
         this.validate(reporterOptions, 'username');
         this.validate(reporterOptions, 'password');
         this.validate(reporterOptions, 'projectId');
-        this.validate(reporterOptions, 'suiteId');
+        this.validateEither(reporterOptions, ['suiteId', 'runId']);
 
         runner.on('start', () => {
         });
@@ -106,6 +106,18 @@ ${this.out.join('\n')}
         }
         if (options[name] == null) {
             throw new Error(`Missing ${name} value. Please update --reporter-options in mocha.opts`);
+        }
+    }
+
+    private validateEither(options: TestRailOptions, names: string[]) {
+        if (options == null) {
+            throw new Error("Missing --reporter-options in mocha.opts");
+        }
+
+        if (!names.reduce((previousValue, currentValue) => {
+            return previousValue || options[currentValue] != null
+        }, false)) {
+            throw new Error(`Missing either options of: ${names.join(", ")}. Please update --reporter-options in mocha.opts`);
         }
     }
 }

--- a/src/lib/testrail.interface.ts
+++ b/src/lib/testrail.interface.ts
@@ -3,7 +3,8 @@ export interface TestRailOptions {
     username: string,
     password: string,
     projectId: number,
-    suiteId: number,
+    runId?: number,
+    suiteId?: number,
     assignedToId?: number,
 }
 

--- a/src/test/helpers/mock-runner.ts
+++ b/src/test/helpers/mock-runner.ts
@@ -1,0 +1,68 @@
+/**
+ * Adapted from: https://github.com/michaelleeallen/mocha-junit-reporter/blob/master/test/helpers/mock-runner.js
+ */
+'use strict';
+
+import {EventEmitter} from 'events';
+const util = require('util');
+
+export class Runner extends EventEmitter {
+  _currentSuite: any;
+    constructor() {
+        super()
+    }
+
+    public start() {
+      this.emit('start');
+    }
+
+    public end() {
+      this.emit('end');
+    };
+
+    public startSuite(suite: any) {
+      suite.suites = suite.suites || [];
+      suite.tests = suite.tests || [];
+
+      if (this._currentSuite) {
+        suite.parent = this._currentSuite;
+      }
+
+      this._currentSuite = suite;
+      this.emit('suite', suite);
+    }
+
+    public pass(test) {
+      this.emit('pass', test);
+      this.endTest();
+    };
+
+    public fail(test, reason) {
+      this.emit('fail', test, reason);
+      this.endTest();
+    };
+
+    public pending(test) {
+      this.emit('pending', test);
+      this.endTest();
+    };
+
+    public endTest() {
+      this.emit('end test');
+    };
+}
+
+export class Test {
+  private title;
+  private duration;
+  private fullTitle;
+  private slow;
+  constructor(fullTitle, title, duration?) {
+    this.title = title;
+    this.duration = duration;
+    this.fullTitle = function() {
+      return fullTitle;
+    };
+    this.slow = function() {};
+  }
+}

--- a/src/test/reporter.ts
+++ b/src/test/reporter.ts
@@ -1,0 +1,103 @@
+let Reporter = require("../../index.js");
+import { Runner, Test } from "./helpers/mock-runner";
+const assert = require("assert");
+
+describe("Reporter", () => {
+  let runner;
+
+  function executeTestRunner(options) {
+    options = options || {};
+    options.invalidChar = options.invalidChar || "";
+    options.title = options.title || "Foo Bar module";
+    options.root = typeof options.root !== "undefined" ? options.root : false;
+    runner.start();
+
+    runner.startSuite({
+      title: options.title,
+      root: options.root,
+      tests: [1, 2]
+    });
+
+    if (!options.skipPassedTests) {
+      runner.pass(new Test("Foo can weez the juice", "can weez the juice", 1));
+    }
+
+    runner.fail(
+      new Test("Bar can narfle the garthog", "can narfle the garthog", 1),
+      {
+        stack:
+          options.invalidChar +
+          "expected garthog to be dead" +
+          options.invalidChar
+      }
+    );
+
+    runner.fail(
+      new Test("Baz can behave like a flandip", "can behave like a flandip", 1),
+      {
+        name: "BazError",
+        message:
+          "expected baz to be masher, a hustler, an uninvited grasper of cone"
+      }
+    );
+
+    runner.startSuite({
+      title: "Another suite!",
+      tests: [1]
+    });
+
+    runner.pass(new Test("Another suite", "works", 4));
+
+    if (options && options.includePending) {
+      runner.startSuite({
+        title: "Pending suite!",
+        tests: [1]
+      });
+      runner.pending(new Test("Pending suite", "pending"));
+    }
+
+    runner.end();
+  }
+
+  function createReporter(options) {
+    options = options || {};
+    return new Reporter(runner, { reporterOptions: options });
+  }
+
+  beforeEach(function() {
+    runner = new Runner();
+  });
+
+  it("Requires either suiteID or runId", () => {
+    let testFunc = function() {
+      createReporter({
+        domain: process.env.DOMAIN,
+        username: process.env.USERNAME,
+        password: process.env.PASSWORD,
+        projectId: process.env.PROJECT_ID
+      });
+      executeTestRunner({});
+    };
+
+    assert.throws(
+      testFunc,
+      /Error: Missing either options of: suiteId, runId. Please update --reporter-options in mocha.opts/
+    );
+  });
+
+  it("Requires projectId", () => {
+    let testFunc = function() {
+      createReporter({
+        domain: process.env.DOMAIN,
+        username: process.env.USERNAME,
+        password: process.env.PASSWORD
+      });
+      executeTestRunner({});
+    };
+
+    assert.throws(
+      testFunc,
+      /Missing projectId value. Please update --reporter-options in mocha.opts/
+    );
+  });
+});

--- a/src/test/testrail.ts
+++ b/src/test/testrail.ts
@@ -2,14 +2,39 @@ import {TestRail} from "../lib/testrail";
 import {TestRailResult, TestRailCase, Status} from "../lib/testrail.interface";
 
 describe("TestRail API", () => {
-    it("Publish test run", (done) => {
+    it("Publish test run on current Run ID", (done) => {
         let testRail = new TestRail({
             domain: process.env.DOMAIN,
             username: process.env.USERNAME,
             password: process.env.PASSWORD,
-            projectId: 10,
-            suiteId: 104,
-            // assignedToId: 2,
+            projectId: process.env.PROJECT_ID,
+            runId: process.env.RUN_ID
+        });
+
+        testRail.publish("Unit Test of mocha-testrail-reporter", "Unit Test of mocha-testrail-reporter", [{
+            case_id: process.env.CASE_1,
+            status_id: Status.Passed,
+            comment: "Passing...."
+        }, {
+            case_id: process.env.CASE_2,
+            status_id: Status.Passed
+        }, {
+            case_id: process.env.CASE_3,
+            status_id: Status.Passed
+        }, {
+            case_id: process.env.CASE_4,
+            status_id: Status.Failed,
+            comment: "Failure...."
+        }], done);
+    });
+
+    it("Publish test run on new Run ID", (done) => {
+        let testRail = new TestRail({
+            domain: process.env.DOMAIN,
+            username: process.env.USERNAME,
+            password: process.env.PASSWORD,
+            projectId: process.env.PROJECT_ID,
+            suiteId: process.env.SUITE_ID,
         });
 
         testRail.fetchCases({type_id: [3], priority_id: [4]}, (cases: TestRailCase[]) => {
@@ -21,17 +46,17 @@ describe("TestRail API", () => {
         });
 
         testRail.publish("Unit Test of mocha-testrail-reporter", "Unit Test of mocha-testrail-reporter", [{
-            case_id: 3033,
+            case_id: process.env.CASE_ID_1,
             status_id: Status.Passed,
             comment: "Passing...."
         }, {
-            case_id: 3034,
+            case_id: process.env.CASE_ID_2,
             status_id: Status.Passed
         }, {
-            case_id: 3035,
+            case_id: process.env.CASE_ID_3,
             status_id: Status.Passed
         }, {
-            case_id: 3036,
+            case_id: process.env.CASE_ID_4,
             status_id: Status.Failed,
             comment: "Failure...."
         }], done);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,11 @@
     "noImplicitAny": false,
     "pretty": true,
     "outDir": "dist",
-    "typeRoots": ["node_modules/@types"]
+    "typeRoots": ["node_modules/@types"],
+    "lib": [
+        "dom",
+        "es2016"
+    ],
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
New Feature:
When `runId` is provided, reporter will not create a new test run.

Other changes:
Added test for reporter itself to verify mandatory and optional options.
Use `.env` to control test data via dotenv.